### PR TITLE
Tests Refactoring

### DIFF
--- a/Tests/stella-implementation-in-swiftTests/stella_implementation_in_swiftTests.swift
+++ b/Tests/stella-implementation-in-swiftTests/stella_implementation_in_swiftTests.swift
@@ -2,57 +2,36 @@ import XCTest
 @testable import stella_implementation_in_swift
 
 final class stella_implementation_in_swiftTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-
-        // Get path to DefaultSettings.plist file.
+        
+    // MARK: - Tests
     
-        let bundle = Bundle(for: type(of: self))
-        
-        // FIXME: apparently, Swift's Bundle has a bug and does not compute resource path correctly
-        let resourcePath = bundle.resourcePath! + "/stella-implementation-in-swift_stella-implementation-in-swiftTests.bundle/Contents/Resources/Resources"
-        
-        let well_typed_tests = [
-            "factorial",
-            "increment_twice",
-            "higher-order-1",
-            "logical-operators",
-            "squares"
-        ]
-        
-        well_typed_tests.forEach({
-            (name : String) -> () in
-            let path = resourcePath + "/well-typed/" + name + ".stella"
-            print("Typechecking " + path)
-            XCTAssertNoThrow(stella_implementation_in_swift.typecheck_file(filepath: path))
-        })
-        
-        let ill_typed_tests = [
-            "bad-squares-1",
-            "bad-squares-2",
-            "applying-non-function-1",
-            "applying-non-function-2",
-            "applying-non-function-3",
-            "argument-type-mismatch-1",
-            "argument-type-mismatch-2",
-            "argument-type-mismatch-3",
-            "bad-if-1",
-            "bad-if-2",
-            "bad-succ-1",
-            "bad-succ-2",
-            "bad-succ-3",
-            "shadowed-variable-1",
-            "undefined-variable-1",
-            "undefined-variable-2"
-        ]
-        
-        ill_typed_tests.forEach({
-            (name : String) -> () in
-            let path = resourcePath + "/ill-typed/" + name + ".stella"
-            print("Typechecking " + path)
-            XCTAssertThrowsError(stella_implementation_in_swift.typecheck_file(filepath: path))
-        })
+    func testWellTyped() {
+        let resourcePath = "\(Bundle.module.resourcePath!)/Resources"
+        let filepaths = filepaths(in: resourcePath + "/well-typed")
+        filepaths.forEach { filepath in
+            print("Typechecking \(filepath)")
+            XCTAssertNoThrow(stella_implementation_in_swift.typecheck_file(filepath: filepath))
+        }
     }
+    
+    func testIllTyped() {
+        let resourcePath = "\(Bundle.module.resourcePath!)/Resources"
+        let filepaths = filepaths(in: resourcePath + "/ill-typed")
+        filepaths.forEach { filepath in
+            print("Typechecking \(filepath)")
+            XCTAssertThrowsError(stella_implementation_in_swift.typecheck_file(filepath: filepath))
+        }
+    }
+                             
+    // MARK: - Private Helpers
+    
+    private func filepaths(in path: String) -> [String] {
+        let contents = try! FileManager.default.contentsOfDirectory(
+            at: URL(string: path)!,
+            includingPropertiesForKeys: nil
+        )
+        
+        return contents.filter { $0.hasDirectoryPath == false }.map { $0.path }
+    }
+    
 }


### PR DESCRIPTION
Actually there is a [bug](https://forums.swift.org/t/swift-5-3-spm-resources-in-tests-uses-wrong-bundle-path/37051/44) that Swift's Bundle does not compute resource path correctly and it fixed only in xcode 14.4 (beta)
But we can get the path using `Bundle.module`.

1. Implement helper method `filepaths(in path: String)` that return all the files paths in the specified folder
2. Decomposed tests into two parts