### PR TITLE
AST Refactoring

### DIFF
--- a/Sources/stella-implementation-in-swift/ast.swift
+++ b/Sources/stella-implementation-in-swift/ast.swift
@@ -8,55 +8,58 @@
 public typealias ExtensionName = String
 
 public struct Program {
-    var language_decl: LanguageDecl
+    var languageDecl: LanguageDecl
     var extensions: Array<Extension>
     var decls: Array<Decl>
 }
 
 public enum LanguageDecl {
-    case LanguageCore
+    case languageCore
 }
 
 public struct Extension {
-    var extension_names: Array<ExtensionName>
+    var extensionNames: Array<ExtensionName>
 }
 
 public enum Decl {
-    case DeclFun(
-        Array<Annotation>,
-        String,
-        Array<ParamDecl>,
-        StellaType?,
-        StellaType?,
-        Array<Decl>,
-        Expr
+    case declFun(
+        annotations: Array<Annotation>,
+        name: String,
+        paramDecls: Array<ParamDecl>,
+        returnType: StellaType?,
+        throwsType: StellaType?,
+        localDecls: Array<Decl>,
+        returnExpr: Expr
     )
-    case DeclTypeAlias(String, StellaType)
+    case declTypeAlias(
+        name: String,
+        type: StellaType
+    )
 }
 
 public enum Annotation {
-    case InlineAnnotation
+    case inlineAnnotation
 }
 
 public struct ParamDecl {
     var name: String
-    var type_: StellaType
+    var type: StellaType
 }
 
 public indirect enum Expr {
-    case If(Expr, Expr, Expr)
-    case Abstraction(Array<ParamDecl>, Expr)
-    case Application(Expr, Array<Expr>)
-    case Succ(Expr)
-    case NatRec(Expr, Expr, Expr)
-    case ConstTrue
-    case ConstFalse
-    case ConstInt(Int)
-    case Var(String)
+    case `if`(expr1: Expr, expr2: Expr, expr3: Expr)
+    case abstraction(paramDecls: Array<ParamDecl>, expr: Expr)
+    case application(expr: Expr, exprs: Array<Expr>)
+    case succ(expr: Expr)
+    case natRec(expr1: Expr, expr2: Expr, expr3: Expr)
+    case constTrue
+    case constFalse
+    case constInt(value: Int)
+    case `var`(name: String)
 }
 
 public indirect enum StellaType {
-    case Fun(Array<StellaType>, StellaType)
-    case Bool
-    case Nat
+    case fun(parameterTypes: Array<StellaType>, returnType: StellaType)
+    case bool
+    case nat
 }

--- a/Sources/stella-implementation-in-swift/build.swift
+++ b/Sources/stella-implementation-in-swift/build.swift
@@ -12,18 +12,22 @@ public enum BuildError : Error {
 }
 
 public func build_param_decl(ctx : stellaParser.ParamDeclContext) throws -> ParamDecl {
-    return try ParamDecl(name: ctx.name.getText()!, type_: build_type(ctx: ctx.paramType))
+    return try ParamDecl(name: ctx.name.getText()!, type: build_type(ctx: ctx.paramType))
 }
 
 public func build_type(ctx : stellaParser.StellatypeContext) throws -> StellaType {
     switch ctx {
-    case is stellaParser.TypeBoolContext: return StellaType.Bool
-    case is stellaParser.TypeNatContext: return StellaType.Nat
-    case let ctx as stellaParser.TypeFunContext: return try StellaType.Fun(
-        ctx.paramTypes.map(build_type),
-        build_type(ctx: ctx.returnType)
+    case is stellaParser.TypeBoolContext: return StellaType.bool
+            
+    case is stellaParser.TypeNatContext: return StellaType.nat
+            
+    case let ctx as stellaParser.TypeFunContext: return try StellaType.fun(
+        parameterTypes: ctx.paramTypes.map(build_type),
+        returnType: build_type(ctx: ctx.returnType)
     )
+            
     case let ctx as stellaParser.TypeParensContext: return try build_type(ctx: ctx.type_)
+            
     default:
         throw BuildError.UnexpectedParseContext("not a type")
     }
@@ -31,33 +35,48 @@ public func build_type(ctx : stellaParser.StellatypeContext) throws -> StellaTyp
 
 public func build_expr(ctx : stellaParser.ExprContext) throws -> Expr {
     switch ctx {
-    case is stellaParser.ConstFalseContext: return Expr.ConstFalse
-    case is stellaParser.ConstTrueContext: return Expr.ConstTrue
-    case let ctx as stellaParser.IfContext: return try Expr.If(
-        build_expr(ctx: ctx.condition),
-        build_expr(ctx: ctx.thenExpr),
-        build_expr(ctx: ctx.elseExpr)
+    case is stellaParser.ConstFalseContext: return Expr.constFalse
+            
+    case is stellaParser.ConstTrueContext: return Expr.constTrue
+            
+    case let ctx as stellaParser.IfContext: return try Expr.if(
+        expr1: build_expr(ctx: ctx.condition),
+        expr2: build_expr(ctx: ctx.thenExpr),
+        expr3: build_expr(ctx: ctx.elseExpr)
     )
         
-    case let ctx as stellaParser.ConstIntContext: return Expr.ConstInt(Int(ctx.INTEGER()!.getText())!)
-    case let ctx as stellaParser.SuccContext: return try Expr.Succ(build_expr(ctx: ctx.n))
-    case let ctx as stellaParser.NatRecContext: return try Expr.NatRec(
-        build_expr(ctx: ctx.n),
-        build_expr(ctx: ctx.initial),
-        build_expr(ctx: ctx.step)
+                                                                
+    case let ctx as stellaParser.ConstIntContext: return Expr.constInt(
+        value: Int(ctx.INTEGER()!.getText())!
+    )
+                                                                
+    case let ctx as stellaParser.SuccContext: return try Expr.succ(
+        expr: build_expr(ctx: ctx.n)
+    )
+                                                                
+    case let ctx as stellaParser.NatRecContext: return try Expr.natRec(
+        expr1: build_expr(ctx: ctx.n),
+        expr2: build_expr(ctx: ctx.initial),
+        expr3: build_expr(ctx: ctx.step)
     )
         
-    case let ctx as stellaParser.AbstractionContext: return try Expr.Abstraction(
-        ctx.paramDecls.map(build_param_decl),
-        build_expr(ctx: ctx.returnExpr)
+    case let ctx as stellaParser.AbstractionContext: return try Expr.abstraction(
+        paramDecls: ctx.paramDecls.map(build_param_decl),
+        expr: build_expr(ctx: ctx.returnExpr)
     )
-    case let ctx as stellaParser.ApplicationContext: return try Expr.Application(
-        build_expr(ctx: ctx.fun),
-        ctx.args.map(build_expr)
+                                                                
+    case let ctx as stellaParser.ApplicationContext: return try Expr.application(
+        expr: build_expr(ctx: ctx.fun),
+        exprs: ctx.args.map(build_expr)
     )
         
-    case let ctx as stellaParser.VarContext: return Expr.Var(ctx.getText())
-    case let ctx as stellaParser.ExprParensContext: return try build_expr(ctx: ctx.expr_)
+    case let ctx as stellaParser.VarContext: return Expr.var(
+        name: ctx.getText()
+    )
+                                                                
+    case let ctx as stellaParser.ExprParensContext: return try build_expr(
+        ctx: ctx.expr_
+    )
         
     default:
         throw BuildError.UnexpectedParseContext("not an expr")
@@ -66,19 +85,21 @@ public func build_expr(ctx : stellaParser.ExprContext) throws -> Expr {
 
 public func build_decl(ctx : stellaParser.DeclContext) throws -> Decl {
     switch ctx {
-        case let ctx as stellaParser.DeclFunContext: return try Decl.DeclFun(
-            Array(), // TODO: annotations
-            ctx.name.getText()!,
-            ctx.paramDecls.map(build_param_decl),
-            ctx.returnType.map(build_type),
-            ctx.throwType.map(build_type),
-            ctx.localDecls.map(build_decl),
-            build_expr(ctx: ctx.returnExpr!)
-        )
-        case let ctx as stellaParser.DeclTypeAliasContext: return try Decl.DeclTypeAlias(
-            ctx.name.getText()!,
-            build_type(ctx: ctx.atype!)
+    case let ctx as stellaParser.DeclFunContext: return try Decl.declFun(
+        annotations: Array(), // TODO: annotations
+        name: ctx.name.getText()!,
+        paramDecls: ctx.paramDecls.map(build_param_decl),
+        returnType: ctx.returnType.map(build_type),
+        throwsType: ctx.throwType.map(build_type),
+        localDecls: ctx.localDecls.map(build_decl),
+        returnExpr: build_expr(ctx: ctx.returnExpr!)
     )
+    
+    case let ctx as stellaParser.DeclTypeAliasContext: return try Decl.declTypeAlias(
+        name: ctx.name.getText()!,
+        type: build_type(ctx: ctx.atype!)
+    )
+            
     default:
         throw BuildError.UnexpectedParseContext("not a declaration")
     }
@@ -88,7 +109,7 @@ public func build_program(ctx : stellaParser.ProgramContext) throws -> Program {
     // TODO: ctx.languageDecl()
     // TODO: ctx.extensions
     return try Program(
-        language_decl: LanguageDecl.LanguageCore,
+        languageDecl: LanguageDecl.languageCore,
         extensions: Array(),
         decls: ctx.decls.map(build_decl)
     )

--- a/Sources/stella-implementation-in-swift/stella_implementation_in_swift.swift
+++ b/Sources/stella-implementation-in-swift/stella_implementation_in_swift.swift
@@ -10,7 +10,7 @@ public struct stella_implementation_in_swift {
             let ctx = try parser.program()
             let program = try build_program(ctx: ctx)
             
-            typecheck_program(program: program)
+            typecheck(program: program)
         }
         catch {
             print(error)

--- a/Sources/stella-implementation-in-swift/typecheck.swift
+++ b/Sources/stella-implementation-in-swift/typecheck.swift
@@ -5,16 +5,17 @@
 //  Created by Nikolai Kudasov on 27.03.2023.
 //
 
-public func typecheck_decl(decl : Decl) {
+public func typecheck(decl: Decl) {
     switch decl {
-    case .DeclFun(_, let name, let paramDecls, let returnType, _, _, let returnExpr):
+    case .declFun(_, let name, _, _, _, _, _):
         print("Declaring function " + name)
         return
-    case .DeclTypeAlias(_, _):
+            
+    case .declTypeAlias(_, _):
         return
     }
 }
 
-public func typecheck_program(program : Program) {
-    program.decls.forEach(typecheck_decl)
+public func typecheck(program: Program) {
+    program.decls.forEach { typecheck(decl: $0) }
 }


### PR DESCRIPTION
- Change names in `AST.swift` accoring to [swift](https://www.swift.org/documentation/api-design-guidelines/#conventions) style guide:

> Follow case conventions. Names of types and protocols are UpperCamelCase. Everything else is lowerCamelCase.

- Add case parameters names