### PR TITLE
Tests Refactoring #2

### DIFF
--- a/Sources/stella-implementation-in-swift/stella_implementation_in_swift.swift
+++ b/Sources/stella-implementation-in-swift/stella_implementation_in_swift.swift
@@ -3,24 +3,25 @@ import Foundation
 
 @main
 public struct stella_implementation_in_swift {
-    public static func typecheck_file(filepath: String) {
+    
+    public static func typecheck_file(filepath: String) throws {
         let lexer = try! stellaLexer(ANTLRInputStream(String(contentsOfFile: filepath)));
-        do {
-            let parser = try stellaParser(CommonTokenStream(lexer))
-            let ctx = try parser.program()
-            let program = try build_program(ctx: ctx)
-            
-            typecheck(program: program)
-        }
-        catch {
-            print(error)
-            print("Parse Error occurred. See the message above.")
-        }
+        
+        let parser = try stellaParser(CommonTokenStream(lexer))
+        let ctx = try parser.program()
+        let program = try build_program(ctx: ctx)
+        
+        try typecheck(program: program)
     }
     
     public static func main() {
-        
         assert(CommandLine.arguments[1] == "typecheck")
-        typecheck_file(filepath: CommandLine.arguments[2])
+        
+        do {
+            try typecheck_file(filepath: CommandLine.arguments[2])
+        } catch {
+            print(error)
+            print("Parse Error occurred. See the message above.")
+        }
     }
 }

--- a/Sources/stella-implementation-in-swift/typecheck.swift
+++ b/Sources/stella-implementation-in-swift/typecheck.swift
@@ -16,6 +16,6 @@ public func typecheck(decl: Decl) {
     }
 }
 
-public func typecheck(program: Program) {
+public func typecheck(program: Program) throws {
     program.decls.forEach { typecheck(decl: $0) }
 }

--- a/Tests/stella-implementation-in-swiftTests/stella_implementation_in_swiftTests.swift
+++ b/Tests/stella-implementation-in-swiftTests/stella_implementation_in_swiftTests.swift
@@ -5,21 +5,29 @@ final class stella_implementation_in_swiftTests: XCTestCase {
         
     // MARK: - Tests
     
-    func testWellTyped() {
+    func testWellTyped() throws {
         let resourcePath = "\(Bundle.module.resourcePath!)/Resources"
         let filepaths = filepaths(in: resourcePath + "/well-typed")
-        filepaths.forEach { filepath in
-            print("Typechecking \(filepath)")
-            XCTAssertNoThrow(stella_implementation_in_swift.typecheck_file(filepath: filepath))
+        
+        for filepath in filepaths {
+            print("Typechecking file <\(filepath.split(separator: "/").last!)>")
+            XCTAssertNoThrow(try stella_implementation_in_swift.typecheck_file(filepath: filepath))
+            print()
         }
     }
-    
-    func testIllTyped() {
+
+    func testIllTyped() throws {
         let resourcePath = "\(Bundle.module.resourcePath!)/Resources"
         let filepaths = filepaths(in: resourcePath + "/ill-typed")
-        filepaths.forEach { filepath in
-            print("Typechecking \(filepath)")
-            XCTAssertThrowsError(stella_implementation_in_swift.typecheck_file(filepath: filepath))
+        
+        for filepath in filepaths {
+            print("Typechecking file <\(filepath.split(separator: "/").last!)>")
+            XCTAssertThrowsError(
+                try stella_implementation_in_swift.typecheck_file(filepath: filepath)
+            ) { error in
+                print(error.localizedDescription)
+            }
+            print()
         }
     }
                              


### PR DESCRIPTION
After implementing typechecker I come up with final version of tests.

**Changes:**
1. Add throws to `typecheck_file(filepath: )`, since we want to catch an error in `XCTAssertThrowsError`
2. Start to print only file names to console because it was hard to see the full path to the test file
3. Add error printing in `testIllTyped()`